### PR TITLE
Add support for navigating to the last used space

### DIFF
--- a/Blink/Bindings/BoundAction.swift
+++ b/Blink/Bindings/BoundAction.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum BoundAction: String, Codable, CaseIterable {
     case left, right
+    case lastUsedSpace
     case space1, space2, space3, space4, space5
     case space6, space7, space8, space9, space10
 
@@ -16,6 +17,7 @@ enum BoundAction: String, Codable, CaseIterable {
         switch self {
         case .left: return "Switch Left"
         case .right: return "Switch Right"
+        case .lastUsedSpace: return "Switch to Last Used Space"
         case .space1: return "Space 1"
         case .space2: return "Space 2"
         case .space3: return "Space 3"
@@ -35,6 +37,7 @@ enum BoundAction: String, Codable, CaseIterable {
         switch self {
         case .left: switcher.switchLeft()
         case .right: switcher.switchRight()
+        case .lastUsedSpace: switcher.switchToLastUsedSpace()
         case .space1: switcher.switchToIndex(0)
         case .space2: switcher.switchToIndex(1)
         case .space3: switcher.switchToIndex(2)
@@ -56,6 +59,7 @@ extension BoundAction {
         switch self {
         case .left: return .init(key: .leftArrow, modifiers: swipeModifiers)
         case .right: return .init(key: .rightArrow, modifiers: swipeModifiers)
+        case .lastUsedSpace: return nil
         case .space1: return .init(key: .one, modifiers: jumpModifiers)
         case .space2: return .init(key: .two, modifiers: jumpModifiers)
         case .space3: return KeyCombination(key: .three, modifiers: jumpModifiers)

--- a/Blink/Core/SpaceSwitcher.swift
+++ b/Blink/Core/SpaceSwitcher.swift
@@ -139,6 +139,7 @@ final class SpaceSwitcher {
     private(set) weak var appState: AppState?
 
     private(set) var spaceInfo: SpaceInfo?
+    private var lastUsedSpaceInfo: SpaceInfo?
 
     private let symbols: CGSSymbols?
 
@@ -203,12 +204,33 @@ final class SpaceSwitcher {
         return postInstantGestures(direction, count: steps)
     }
 
+    @discardableResult
+    func switchToLastUsedSpace() -> Bool {
+        guard let lastUsedSpaceInfo else { return false }
+        return switchToIndex(lastUsedSpaceInfo.currentIndex)
+    }
+
     func canMoveLeft() -> Bool { spaceInfo.map { !$0.isAtLeftEdge } ?? false }
     func canMoveRight() -> Bool { spaceInfo.map { !$0.isAtRightEdge } ?? false }
 
     func refreshSpaceInfo() {
         // Use the menu-bar display for the icon (always correct on multi-monitor)
-        spaceInfo = loadSpaceInfo(useCursorDisplay: false)
+        let newSpaceInfo = loadSpaceInfo(useCursorDisplay: false)
+
+        if let currentSpaceInfo = spaceInfo, let newSpaceInfo {
+            let activeSpaceChanged: Bool = if let currentSpaceID = currentSpaceInfo.currentSpaceID,
+                                              let newSpaceID = newSpaceInfo.currentSpaceID {
+                currentSpaceID != newSpaceID
+            } else {
+                currentSpaceInfo.currentIndex != newSpaceInfo.currentIndex
+            }
+
+            if activeSpaceChanged {
+                lastUsedSpaceInfo = currentSpaceInfo
+            }
+        }
+
+        spaceInfo = newSpaceInfo
         // debugLogSpaceInfo()
     }
 

--- a/Blink/Settings/SettingsPanes/HotkeysSettingsPane.swift
+++ b/Blink/Settings/SettingsPanes/HotkeysSettingsPane.swift
@@ -22,6 +22,7 @@ struct HotkeysSettingsPane: View {
             BlinkSection("Change Spaces") {
                 hotkeyRecorder(forAction: .left)
                 hotkeyRecorder(forAction: .right)
+                hotkeyRecorder(forAction: .lastUsedSpace)
             }
             BlinkSection("Jump to Index") {
                 hotkeyRecorder(forAction: .space1)


### PR DESCRIPTION
This turned out to be such a small change, so I just went ahead and implemented it.
Take it or leave it :)

## Description
Add new keyboard shortcut for switching back and forward between the last used space.

Fixes: https://github.com/benkoppe/Blink/issues/6