### PR TITLE
feat: Last used space

### DIFF
--- a/Blink/Bindings/BoundAction.swift
+++ b/Blink/Bindings/BoundAction.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum BoundAction: String, Codable, CaseIterable {
-    case left, right
+    case left, right, lastSpace
     case space1, space2, space3, space4, space5
     case space6, space7, space8, space9, space10
 
@@ -16,6 +16,7 @@ enum BoundAction: String, Codable, CaseIterable {
         switch self {
         case .left: return "Switch Left"
         case .right: return "Switch Right"
+        case .lastSpace: return "Last Space"
         case .space1: return "Space 1"
         case .space2: return "Space 2"
         case .space3: return "Space 3"
@@ -35,6 +36,7 @@ enum BoundAction: String, Codable, CaseIterable {
         switch self {
         case .left: switcher.switchLeft()
         case .right: switcher.switchRight()
+        case .lastSpace: switcher.switchToLastSpace()
         case .space1: switcher.switchToIndex(0)
         case .space2: switcher.switchToIndex(1)
         case .space3: switcher.switchToIndex(2)
@@ -56,6 +58,7 @@ extension BoundAction {
         switch self {
         case .left: return .init(key: .leftArrow, modifiers: swipeModifiers)
         case .right: return .init(key: .rightArrow, modifiers: swipeModifiers)
+        case .lastSpace: return .init(key: .grave, modifiers: jumpModifiers)
         case .space1: return .init(key: .one, modifiers: jumpModifiers)
         case .space2: return .init(key: .two, modifiers: jumpModifiers)
         case .space3: return KeyCombination(key: .three, modifiers: jumpModifiers)

--- a/Blink/BlinkMenu.swift
+++ b/Blink/BlinkMenu.swift
@@ -31,11 +31,13 @@ struct BlinkMenu: View {
                 BoundAction.left.execute(appState: appState)
             }
             .keyboardShortcut(from: hotkey(for: .left))
+            .disabled(!switcher.canMoveLeft())
 
             Button("Switch right", systemImage: "arrow.right") {
                 BoundAction.right.execute(appState: appState)
             }
             .keyboardShortcut(from: hotkey(for: .right))
+            .disabled(!switcher.canMoveRight())
         }
     }
 

--- a/Blink/BlinkMenu.swift
+++ b/Blink/BlinkMenu.swift
@@ -41,12 +41,23 @@ struct BlinkMenu: View {
         }
     }
 
-    private var jumpSelection: Binding<Int?> {
+    enum JumpSelection: Hashable {
+        case lastSpace
+        case index(_ index: Int)
+    }
+
+    private var jumpSelection: Binding<JumpSelection?> {
         Binding(
-            get: { switcher.spaceInfo?.currentIndex },
+            get: {
+                guard let index = switcher.spaceInfo?.currentIndex else { return nil }
+                return .index(index)
+            },
             set: { newValue in
-                guard let index = newValue else { return }
-                _ = switcher.switchToIndex(index)
+                guard let selection = newValue else { return }
+                switch selection {
+                case .lastSpace: switcher.switchToLastSpace()
+                case .index(let index): switcher.switchToIndex(index)
+                }
             }
         )
     }
@@ -59,6 +70,13 @@ struct BlinkMenu: View {
                     "Jump to...", systemImage: "square.and.line.vertical.and.square",
                     selection: jumpSelection
                 ) {
+                    Text("Last Space")
+                        .selectionDisabled(!switcher.canSwitchToLastSpace())
+                        .keyboardShortcut(from: hotkey(for: BoundAction.lastSpace))
+                        .tag(Optional(JumpSelection.lastSpace))
+
+                    Divider()
+
                     ForEach(0..<info.spaceCount, id: \.self) { index in
                         Text("Space \(index + 1)")
                             .keyboardShortcut(
@@ -66,7 +84,7 @@ struct BlinkMenu: View {
                                     ? hotkey(for: BoundAction.indexedSpaceActions[index])
                                     : nil
                             )
-                            .tag(Optional(index))
+                            .tag(Optional(JumpSelection.index(index)))
                     }
                 }
             }

--- a/Blink/Core/SpaceSwitcher.swift
+++ b/Blink/Core/SpaceSwitcher.swift
@@ -240,19 +240,19 @@ final class SpaceSwitcher {
     func switchToLastSpace() -> Bool {
         guard let snapshot = refreshSnapshot() else { return false }
         let info = actionSpaceInfo(in: snapshot)
-
-        guard
-            info.spaceCount > 0,
-            let displayIdentifier = info.displayIdentifier,
-            let lastSpaceID = lastSpaceIDByDisplay[displayIdentifier],
-            let targetIndex = info.index(ofSpaceID: lastSpaceID)
-        else { return false }
+        guard let targetIndex = lastSpaceTargetIndex(using: info) else { return false }
 
         return moveToIndex(targetIndex, using: info)
     }
 
-    func canMoveLeft() -> Bool { spaceInfo.map { !$0.isAtLeftEdge } ?? false }
-    func canMoveRight() -> Bool { spaceInfo.map { !$0.isAtRightEdge } ?? false }
+    func canMoveLeft() -> Bool { canMove(.left) }
+    func canMoveRight() -> Bool { canMove(.right) }
+
+    func canSwitchToLastSpace() -> Bool {
+        guard let snapshot else { return false }
+        let info = actionSpaceInfo(in: snapshot)
+        return lastSpaceTargetIndex(using: info) != nil
+    }
 
     func refreshSpaceInfo() {
         _ = refreshSnapshot()
@@ -445,6 +445,40 @@ final class SpaceSwitcher {
         }
 
         return didPost
+    }
+
+    private func canMove(_ direction: Direction) -> Bool {
+        guard let snapshot else { return false }
+
+        let info = actionSpaceInfo(in: snapshot)
+        guard info.spaceCount > 0 else { return false }
+
+        if wrapSpaces { return true }
+
+        let missionControlActive = isMissionControlActive(on: info.displayIdentifier)
+        let currentIndex = missionControlActive ? info.currentIndex : currentIndex(for: info)
+
+        switch direction {
+        case .left:
+            return currentIndex > 0
+        case .right:
+            return currentIndex + 1 < info.spaceCount
+        }
+    }
+
+    private func lastSpaceTargetIndex(using info: SpaceInfo) -> Int? {
+        guard
+            info.spaceCount > 0,
+            let displayIdentifier = info.displayIdentifier,
+            let lastSpaceID = lastSpaceIDByDisplay[displayIdentifier],
+            let targetIndex = info.index(ofSpaceID: lastSpaceID)
+        else { return nil }
+
+        let missionControlActive = isMissionControlActive(on: info.displayIdentifier)
+        let currentIndex = missionControlActive ? info.currentIndex : currentIndex(for: info)
+
+        guard targetIndex != currentIndex else { return nil }
+        return targetIndex
     }
 
     private enum OverlayMode: String {

--- a/Blink/Core/SpaceSwitcher.swift
+++ b/Blink/Core/SpaceSwitcher.swift
@@ -120,6 +120,7 @@ private let kInstantGestureChunkInterval: TimeInterval = 0.040
 struct SpaceInfo: Equatable {
     let currentIndex: Int
     let spaceCount: Int
+    let spaceIDs: [UInt64]
 
     var displayNumber: Int { currentIndex + 1 }
     var isAtLeftEdge: Bool { currentIndex == 0 }
@@ -136,6 +137,36 @@ struct SpaceInfo: Equatable {
     var isKnownStandardSpace: Bool {
         isNormalDesktopSpace || isFullscreenSpace
     }
+
+    func index(ofSpaceID spaceID: UInt64) -> Int? {
+        spaceIDs.firstIndex(of: spaceID)
+    }
+}
+
+private struct SpaceSnapshot {
+    let spaceInfoByDisplay: [String: SpaceInfo]
+    let fallbackSpaceInfo: SpaceInfo
+    let menuBarDisplayIdentifier: String?
+
+    var menuBarSpaceInfo: SpaceInfo {
+        if let menuBarDisplayIdentifier,
+            let info = spaceInfoByDisplay[menuBarDisplayIdentifier]
+        {
+            return info
+        }
+
+        return fallbackSpaceInfo
+    }
+
+    func spaceInfo(for displayIdentifier: String?) -> SpaceInfo {
+        if let displayIdentifier,
+            let info = spaceInfoByDisplay[displayIdentifier]
+        {
+            return info
+        }
+
+        return menuBarSpaceInfo
+    }
 }
 
 // MARK: - SpaceSwitcher
@@ -145,11 +176,16 @@ final class SpaceSwitcher {
     /// The shared app state.
     private(set) weak var appState: AppState?
 
-    private(set) var spaceInfo: SpaceInfo?
+    var spaceInfo: SpaceInfo? {
+        guard let snapshot else { return nil }
+        return applyingOptimisticIndex(to: snapshot.menuBarSpaceInfo)
+    }
 
     private let symbols: CGSSymbols?
 
-    private var optimisticCurrentIndex: Int?
+    private var snapshot: SpaceSnapshot?
+    private var optimisticCurrentIndexByDisplay: [String: Int] = [:]
+    private var lastSpaceIDByDisplay: [String: UInt64] = [:]
 
     private var spaceObserver: NSObjectProtocol?
     private var appObserver: NSObjectProtocol?
@@ -193,36 +229,34 @@ final class SpaceSwitcher {
 
     @discardableResult
     func switchToIndex(_ index: Int) -> Bool {
-        let missionControlActive = isMissionControlActive()
+        guard let snapshot = refreshSnapshot() else { return false }
+        let info = actionSpaceInfo(in: snapshot)
+        guard info.spaceCount > 0 else { return false }
 
-        guard let info = loadActionSpaceInfo(), info.spaceCount > 0 else { return false }
-        guard (0..<info.spaceCount).contains(index) else { return false }
-        let currentIndex = missionControlActive ? info.currentIndex : currentIndex(for: info)
-        guard index != currentIndex else {
-            return true
-        }
+        return moveToIndex(index, using: info)
+    }
 
-        let direction: Direction = index > currentIndex ? .right : .left
-        let steps = abs(index - currentIndex)
+    @discardableResult
+    func switchToLastSpace() -> Bool {
+        guard let snapshot = refreshSnapshot() else { return false }
+        let info = actionSpaceInfo(in: snapshot)
 
-        if missionControlActive {
-            return postMissionControlJump(direction, steps: steps)
-        }
+        guard
+            info.spaceCount > 0,
+            let displayIdentifier = info.displayIdentifier,
+            let lastSpaceID = lastSpaceIDByDisplay[displayIdentifier],
+            let targetIndex = info.index(ofSpaceID: lastSpaceID)
+        else { return false }
 
-        return postInstantJump(direction, steps: steps, targetIndex: index)
+        return moveToIndex(targetIndex, using: info)
     }
 
     func canMoveLeft() -> Bool { spaceInfo.map { !$0.isAtLeftEdge } ?? false }
     func canMoveRight() -> Bool { spaceInfo.map { !$0.isAtRightEdge } ?? false }
 
     func refreshSpaceInfo() {
-        // Use the menu-bar display for the icon (always correct on multi-monitor)
-        spaceInfo = loadSpaceInfo(useCursorDisplay: false)
+        _ = refreshSnapshot()
         // debugLogSpaceInfo()
-    }
-
-    private func loadActionSpaceInfo() -> SpaceInfo? {
-        loadSpaceInfo(useCursorDisplay: true) ?? loadSpaceInfo(useCursorDisplay: false) ?? spaceInfo
     }
 
     // MARK - Workspace notifications
@@ -234,7 +268,7 @@ final class SpaceSwitcher {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.optimisticCurrentIndex = nil
+            self?.optimisticCurrentIndexByDisplay.removeAll()
             self?.refreshSpaceInfo()
         }
 
@@ -297,23 +331,120 @@ final class SpaceSwitcher {
         }
     }
 
-    private func currentIndex(for info: SpaceInfo) -> Int {
-        guard let optimisticCurrentIndex else { return info.currentIndex }
-        return max(0, min(optimisticCurrentIndex, info.spaceCount - 1))
+    @discardableResult
+    private func refreshSnapshot() -> SpaceSnapshot? {
+        let previousSnapshot = snapshot
+
+        guard let newSnapshot = loadSpaceSnapshot() else {
+            return snapshot
+        }
+
+        updateLastSpaceHistory(from: previousSnapshot, to: newSnapshot)
+        snapshot = newSnapshot
+
+        return newSnapshot
     }
 
-    private func setOptimisticCurrentIndex(_ index: Int) {
-        optimisticCurrentIndex = index
+    private func actionSpaceInfo(in snapshot: SpaceSnapshot) -> SpaceInfo {
+        snapshot.spaceInfo(for: cursorDisplayIdentifier())
+    }
 
-        guard let info = spaceInfo, (0..<info.spaceCount).contains(index) else { return }
-        spaceInfo = SpaceInfo(
-            currentIndex: index,
+    private func updateLastSpaceHistory(
+        from previousSnapshot: SpaceSnapshot?,
+        to currentSnapshot: SpaceSnapshot
+    ) {
+        guard let previousSnapshot else { return }
+
+        for (displayIdentifier, currentInfo) in currentSnapshot.spaceInfoByDisplay {
+            guard
+                let previousInfo = previousSnapshot.spaceInfoByDisplay[displayIdentifier],
+                let previousSpaceID = previousInfo.currentSpaceID,
+                previousSpaceID != currentInfo.currentSpaceID
+            else { continue }
+
+            lastSpaceIDByDisplay[displayIdentifier] = previousSpaceID
+        }
+
+        let activeDisplayIdentifiers = Set(currentSnapshot.spaceInfoByDisplay.keys)
+        lastSpaceIDByDisplay = lastSpaceIDByDisplay.filter {
+            activeDisplayIdentifiers.contains($0.key)
+        }
+        optimisticCurrentIndexByDisplay = optimisticCurrentIndexByDisplay.filter {
+            activeDisplayIdentifiers.contains($0.key)
+        }
+    }
+
+    private func applyingOptimisticIndex(to info: SpaceInfo) -> SpaceInfo {
+        guard
+            info.spaceCount > 0,
+            let displayIdentifier = info.displayIdentifier,
+            let optimisticCurrentIndex = optimisticCurrentIndexByDisplay[displayIdentifier]
+        else {
+            return info
+        }
+
+        let clampedIndex = max(0, min(optimisticCurrentIndex, info.spaceCount - 1))
+        guard clampedIndex != info.currentIndex else {
+            return info
+        }
+
+        return SpaceInfo(
+            currentIndex: clampedIndex,
             spaceCount: info.spaceCount,
+            spaceIDs: info.spaceIDs,
             currentSpaceID: info.currentSpaceID,
             currentSpaceType: info.currentSpaceType,
             displayIdentifier: info.displayIdentifier,
             frontmostBundleID: info.frontmostBundleID
         )
+    }
+
+    private func currentIndex(for info: SpaceInfo) -> Int {
+        guard
+            let displayIdentifier = info.displayIdentifier,
+            let optimisticCurrentIndex = optimisticCurrentIndexByDisplay[displayIdentifier]
+        else {
+            return info.currentIndex
+        }
+        return max(0, min(optimisticCurrentIndex, info.spaceCount - 1))
+    }
+
+    private func setOptimisticCurrentIndex(_ index: Int, for info: SpaceInfo) {
+        guard let displayIdentifier = info.displayIdentifier else { return }
+        optimisticCurrentIndexByDisplay[displayIdentifier] = index
+    }
+
+    private func rememberCurrentSpaceAsLast(_ info: SpaceInfo) {
+        guard
+            let displayIdentifier = info.displayIdentifier,
+            let currentSpaceID = info.currentSpaceID
+        else { return }
+
+        lastSpaceIDByDisplay[displayIdentifier] = currentSpaceID
+    }
+
+    @discardableResult
+    private func moveToIndex(_ index: Int, using info: SpaceInfo) -> Bool {
+        let missionControlActive = isMissionControlActive(on: info.displayIdentifier)
+
+        guard (0..<info.spaceCount).contains(index) else { return false }
+
+        let currentIndex = missionControlActive ? info.currentIndex : currentIndex(for: info)
+        guard index != currentIndex else { return true }
+
+        let direction: Direction = index > currentIndex ? .right : .left
+        let steps = abs(index - currentIndex)
+
+        let didPost =
+            missionControlActive
+            ? postMissionControlJump(direction, steps: steps)
+            : postInstantJump(direction, steps: steps, targetIndex: index, info: info)
+
+        if didPost {
+            rememberCurrentSpaceAsLast(info)
+        }
+
+        return didPost
     }
 
     private enum OverlayMode: String {
@@ -519,7 +650,17 @@ final class SpaceSwitcher {
         displayBounds: CGRect?,
         debugDescription: String
     ) {
-        let targetDisplayBounds = displayBounds(for: spaceInfo?.displayIdentifier)
+        overlayModeReport(for: spaceInfo?.displayIdentifier)
+    }
+
+    private func overlayModeReport(
+        for displayIdentifier: String?
+    ) -> (
+        mode: OverlayMode,
+        displayBounds: CGRect?,
+        debugDescription: String
+    ) {
+        let targetDisplayBounds = displayBounds(for: displayIdentifier)
         let windowList =
             CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as! [[String: Any]]
 
@@ -575,67 +716,69 @@ final class SpaceSwitcher {
         overlayModeReport().mode == .missionControl
     }
 
+    private func isMissionControlActive(on displayIdentifier: String?) -> Bool {
+        overlayModeReport(for: displayIdentifier).mode == .missionControl
+    }
+
     func isAppExposeActive() -> Bool {
         overlayModeReport().mode == .appExpose
     }
 
-    private func loadSpaceInfo(useCursorDisplay: Bool) -> SpaceInfo? {
+    private func loadSpaceSnapshot() -> SpaceSnapshot? {
         guard let cgs = symbols else { return nil }
 
         let connection = cgs.mainConnectionID()
         guard connection != 0 else { return nil }
 
         let activeSpaceID = cgs.getActiveSpace(connection)
-        guard activeSpaceID != 0 else { return nil }
+        guard
+            activeSpaceID != 0,
+            let rawDisplays = cgs.copyDisplaySpaces(connection, nil)?.takeRetainedValue()
+        else { return nil }
 
-        let displayID: CFString? =
-            useCursorDisplay
-            ? cursorDisplayIdentifier()
-            : cgs.copyMenuBarDisplayID?(connection)?.takeRetainedValue()
+        let menuBarDisplayIdentifier =
+            cgs.copyMenuBarDisplayID?(connection)?.takeRetainedValue() as String?
+        let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
 
-        // Fetch all display/space layout data. Fall back to nil displayID
-        // (all displays) if the targeted display yields no results
-        var rawDisplays = cgs.copyDisplaySpaces(connection, displayID)?
-            .takeRetainedValue()
-        if rawDisplays == nil, displayID != nil {
-            rawDisplays = cgs.copyDisplaySpaces(connection, nil)?
-                .takeRetainedValue()
-        }
-        guard let rawDisplays else { return nil }
-
-        // Find the display dict that matches our target identifier
-        var fallback: NSDictionary?
-        var target: NSDictionary?
+        var spaceInfoByDisplay: [String: SpaceInfo] = [:]
+        var fallbackSpaceInfo: SpaceInfo?
 
         for item in rawDisplays as NSArray {
-            guard let dict = item as? NSDictionary else { continue }
-            if fallback == nil { fallback = dict }
-            if let id = displayID,
-                let dictID = dict["Display Identifier"] as? String,
-                dictID == id as String
-            {
-                target = dict
-                break
+            guard let displayDict = item as? NSDictionary,
+                let info = extractSpaceInfo(
+                    from: displayDict,
+                    globalActiveSpaceID: activeSpaceID,
+                    frontmostBundleID: frontmostBundleID
+                )
+            else { continue }
+
+            if fallbackSpaceInfo == nil {
+                fallbackSpaceInfo = info
+            }
+
+            if let displayIdentifier = info.displayIdentifier {
+                spaceInfoByDisplay[displayIdentifier] = info
             }
         }
 
-        guard let displayDict = target ?? fallback else { return nil }
-        return extractSpaceInfo(
-            from: displayDict,
-            globalActiveSpaceID: activeSpaceID,
-            displayIdentifier: displayDict["Display Identifier"] as? String,
-            frontmostBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        guard let fallbackSpaceInfo else { return nil }
+
+        return SpaceSnapshot(
+            spaceInfoByDisplay: spaceInfoByDisplay,
+            fallbackSpaceInfo: fallbackSpaceInfo,
+            menuBarDisplayIdentifier: menuBarDisplayIdentifier
         )
     }
 
     private func extractSpaceInfo(
         from displayDict: NSDictionary,
         globalActiveSpaceID: UInt64,
-        displayIdentifier: String?,
         frontmostBundleID: String?
     )
         -> SpaceInfo?
     {
+        let displayIdentifier = displayDict["Display Identifier"] as? String
+
         guard let spacesArray = displayDict["Spaces"] as? NSArray else {
             return nil
         }
@@ -652,15 +795,19 @@ final class SpaceSwitcher {
         var count = 0
         var activeIndex = 0
         var foundActive = false
+        var spaceIDs: [UInt64] = []
 
         for item in spacesArray {
             guard let spaceDict = item as? NSDictionary,
                 let id = (spaceDict["id64"] as? NSNumber)?.uint64Value
             else { continue }
+
             if !foundActive && id == activeID {
                 activeIndex = count
                 foundActive = true
             }
+
+            spaceIDs.append(id)
             count += 1
         }
 
@@ -668,6 +815,7 @@ final class SpaceSwitcher {
         return SpaceInfo(
             currentIndex: foundActive ? activeIndex : 0,
             spaceCount: count,
+            spaceIDs: spaceIDs,
             currentSpaceID: currentSpaceID,
             currentSpaceType: currentSpaceType,
             displayIdentifier: displayIdentifier,
@@ -675,18 +823,18 @@ final class SpaceSwitcher {
         )
     }
 
-    private func cursorDisplayIdentifier() -> CFString? {
+    private func cursorDisplayIdentifier() -> String? {
         guard let event = CGEvent(source: nil) else { return nil }
+
         var displayID: CGDirectDisplayID = 0
         var count: UInt32 = 0
         guard
-            CGGetDisplaysWithPoint(event.location, 1, &displayID, &count)
-                == .success,
-            count > 0
+            CGGetDisplaysWithPoint(event.location, 1, &displayID, &count) == .success,
+            count > 0,
+            let uuid = CGDisplayCreateUUIDFromDisplayID(displayID)?.takeRetainedValue()
         else { return nil }
-        let uuid = CGDisplayCreateUUIDFromDisplayID(displayID)?
-            .takeRetainedValue()
-        return CFUUIDCreateString(nil, uuid)
+
+        return CFUUIDCreateString(nil, uuid) as String?
     }
 
     // MARK: - Gesture posting
@@ -704,8 +852,9 @@ final class SpaceSwitcher {
 
     @discardableResult
     private func postGesture(_ direction: Direction) -> Bool {
-        let missionControlActive = isMissionControlActive()
-        let info = loadActionSpaceInfo()
+        let snapshot = refreshSnapshot()
+        let info = snapshot.map(actionSpaceInfo(in:))
+        let missionControlActive = isMissionControlActive(on: info?.displayIdentifier)
 
         if let info {
             let currentIndex = missionControlActive ? info.currentIndex : currentIndex(for: info)
@@ -723,15 +872,21 @@ final class SpaceSwitcher {
                     case .left: info.spaceCount - 1
                     case .right: 0
                     }
-                return switchToIndex(targetIndex)
+
+                return moveToIndex(targetIndex, using: info)
             }
         }
 
-        if missionControlActive {
-            return postMissionControlStep(direction)
+        let didPost =
+            missionControlActive
+            ? postMissionControlStep(direction)
+            : postInstantStep(direction, info: info)
+
+        if didPost, let info {
+            rememberCurrentSpaceAsLast(info)
         }
 
-        return postInstantStep(direction, info: info)
+        return didPost
     }
 
     private func dockSwipeFlagBits(for direction: Direction) -> Int64 {
@@ -807,7 +962,8 @@ final class SpaceSwitcher {
     private func postInstantJump(
         _ direction: Direction,
         steps: Int,
-        targetIndex: Int
+        targetIndex: Int,
+        info: SpaceInfo
     ) -> Bool {
         let velocity = kDefaultInstantGestureVelocity * Double(steps)
 
@@ -816,13 +972,14 @@ final class SpaceSwitcher {
                 direction,
                 steps: steps,
                 velocity: velocity,
-                targetIndex: targetIndex
+                targetIndex: targetIndex,
+                info: info
             )
         }
 
         let didPost = postInstantGestures(direction, count: steps, velocity: velocity)
         if didPost {
-            setOptimisticCurrentIndex(targetIndex)
+            setOptimisticCurrentIndex(targetIndex, for: info)
         }
         return didPost
     }
@@ -832,7 +989,8 @@ final class SpaceSwitcher {
         _ direction: Direction,
         steps: Int,
         velocity: Double,
-        targetIndex: Int
+        targetIndex: Int,
+        info: SpaceInfo
     ) -> Bool {
         let chunkCount = (steps + kInstantGestureChunkSize - 1) / kInstantGestureChunkSize
 
@@ -845,7 +1003,7 @@ final class SpaceSwitcher {
             let chunkSteps = chunkEnd - chunkStart
             _ = self.postInstantGestures(direction, count: chunkSteps, velocity: velocity)
         } completion: { [weak self] in
-            self?.setOptimisticCurrentIndex(targetIndex)
+            self?.setOptimisticCurrentIndex(targetIndex, for: info)
         }
 
         return true
@@ -872,7 +1030,7 @@ final class SpaceSwitcher {
 
         let currentIndex = currentIndex(for: info)
         let targetIndex = direction == .left ? currentIndex - 1 : currentIndex + 1
-        setOptimisticCurrentIndex(targetIndex)
+        setOptimisticCurrentIndex(targetIndex, for: info)
         return true
     }
 

--- a/Blink/Core/SpaceSwitcher.swift
+++ b/Blink/Core/SpaceSwitcher.swift
@@ -169,6 +169,11 @@ private struct SpaceSnapshot {
     }
 }
 
+private struct PendingJump {
+    let originSpaceID: UInt64
+    var targetSpaceID: UInt64
+}
+
 // MARK: - SpaceSwitcher
 
 @Observable
@@ -186,6 +191,7 @@ final class SpaceSwitcher {
     private var snapshot: SpaceSnapshot?
     private var optimisticCurrentIndexByDisplay: [String: Int] = [:]
     private var lastSpaceIDByDisplay: [String: UInt64] = [:]
+    private var pendingJumpByDisplay: [String: PendingJump] = [:]
 
     private var spaceObserver: NSObjectProtocol?
     private var appObserver: NSObjectProtocol?
@@ -268,7 +274,7 @@ final class SpaceSwitcher {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.optimisticCurrentIndexByDisplay.removeAll()
+            self?.clearOptimisticStateForCompletedJumps()
             self?.refreshSpaceInfo()
         }
 
@@ -356,6 +362,15 @@ final class SpaceSwitcher {
         guard let previousSnapshot else { return }
 
         for (displayIdentifier, currentInfo) in currentSnapshot.spaceInfoByDisplay {
+            if let pendingJump = pendingJumpByDisplay[displayIdentifier] {
+                if currentInfo.currentSpaceID == pendingJump.targetSpaceID {
+                    lastSpaceIDByDisplay[displayIdentifier] = pendingJump.originSpaceID
+                    pendingJumpByDisplay.removeValue(forKey: displayIdentifier)
+                    optimisticCurrentIndexByDisplay.removeValue(forKey: displayIdentifier)
+                }
+                continue
+            }
+
             guard
                 let previousInfo = previousSnapshot.spaceInfoByDisplay[displayIdentifier],
                 let previousSpaceID = previousInfo.currentSpaceID,
@@ -370,6 +385,9 @@ final class SpaceSwitcher {
             activeDisplayIdentifiers.contains($0.key)
         }
         optimisticCurrentIndexByDisplay = optimisticCurrentIndexByDisplay.filter {
+            activeDisplayIdentifiers.contains($0.key)
+        }
+        pendingJumpByDisplay = pendingJumpByDisplay.filter {
             activeDisplayIdentifiers.contains($0.key)
         }
     }
@@ -414,13 +432,30 @@ final class SpaceSwitcher {
         optimisticCurrentIndexByDisplay[displayIdentifier] = index
     }
 
-    private func rememberCurrentSpaceAsLast(_ info: SpaceInfo) {
+    private func rememberCurrentSpaceAsLast(_ info: SpaceInfo, targetIndex: Int? = nil) {
         guard
             let displayIdentifier = info.displayIdentifier,
             let currentSpaceID = info.currentSpaceID
         else { return }
 
-        lastSpaceIDByDisplay[displayIdentifier] = currentSpaceID
+        guard
+            let targetIndex,
+            info.spaceIDs.indices.contains(targetIndex)
+        else {
+            if pendingJumpByDisplay[displayIdentifier] == nil {
+                lastSpaceIDByDisplay[displayIdentifier] = currentSpaceID
+            }
+            return
+        }
+
+        if pendingJumpByDisplay[displayIdentifier] == nil {
+            pendingJumpByDisplay[displayIdentifier] = PendingJump(
+                originSpaceID: currentSpaceID,
+                targetSpaceID: info.spaceIDs[targetIndex]
+            )
+        } else {
+            pendingJumpByDisplay[displayIdentifier]?.targetSpaceID = info.spaceIDs[targetIndex]
+        }
     }
 
     @discardableResult
@@ -441,7 +476,7 @@ final class SpaceSwitcher {
             : postInstantJump(direction, steps: steps, targetIndex: index, info: info)
 
         if didPost {
-            rememberCurrentSpaceAsLast(info)
+            rememberCurrentSpaceAsLast(info, targetIndex: index)
         }
 
         return didPost
@@ -479,6 +514,12 @@ final class SpaceSwitcher {
 
         guard targetIndex != currentIndex else { return nil }
         return targetIndex
+    }
+
+    private func clearOptimisticStateForCompletedJumps() {
+        optimisticCurrentIndexByDisplay = optimisticCurrentIndexByDisplay.filter {
+            pendingJumpByDisplay[$0.key] != nil
+        }
     }
 
     private enum OverlayMode: String {

--- a/Blink/Settings/SettingsPanes/HotkeysSettingsPane.swift
+++ b/Blink/Settings/SettingsPanes/HotkeysSettingsPane.swift
@@ -22,6 +22,7 @@ struct HotkeysSettingsPane: View {
             BlinkSection("Change Spaces") {
                 hotkeyRecorder(forAction: .left)
                 hotkeyRecorder(forAction: .right)
+                hotkeyRecorder(forAction: .lastSpace)
             }
             BlinkSection("Jump to Index") {
                 hotkeyRecorder(forAction: .space1)

--- a/Blink/Settings/SettingsPanes/HotkeysSettingsPane.swift
+++ b/Blink/Settings/SettingsPanes/HotkeysSettingsPane.swift
@@ -22,9 +22,11 @@ struct HotkeysSettingsPane: View {
             BlinkSection("Change Spaces") {
                 hotkeyRecorder(forAction: .left)
                 hotkeyRecorder(forAction: .right)
+            }
+            BlinkSection("Jump to") {
                 hotkeyRecorder(forAction: .lastSpace)
             }
-            BlinkSection("Jump to Index") {
+            BlinkSection {
                 hotkeyRecorder(forAction: .space1)
                 hotkeyRecorder(forAction: .space2)
                 hotkeyRecorder(forAction: .space3)


### PR DESCRIPTION
This PR closes #6 (and #7). This implementation of last-used-space tracks space info on a per-display basis, and is robust to large space index jumps that may take short amounts of time or select some spaces mid-animation.

It does some minor restructuring to neatly add a `switchToLastSpace` function, and utilizes it in the new BoundAction `lastSpace`. This is bound to the default keybind `ctrl + option + grave`, and is added to the Menu Bar under the "Jump to..." submenu.

(Oh also this PR includes proper disabled states for left/right swipes in the menu bar, can't be bothered to extract that into its own PR haha)